### PR TITLE
feat(object.has): enable it on nested objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ in a clean and consitent fashion. Nothing more, and nothing less.
   * [json](#json)
     * [`parse`(input: String): Object](#parseinput-string-object)
   * [object](#object)
-    * [`has`(obj: Object, property: String): Boolean](#hasobj-object-property-string-boolean)
+    * [`has`(obj: Object, property: String [, separator: String = '.']): Boolean](#hasobj-object-property-string--separator-string---boolean)
     * [`get`(obj: Object, property: String [, separator: String = '.']): any](#getobj-object-property-string--separator-string---any)
     * [`set`(obj: `object`, property: `string`, value: `any` [, separator: String = '.' ]): Object](#setobj-object-property-string-value-any--separator-string----object)
     * [`filter`(obj: Object, test: Function): Object](#filterobj-object-test-function-object)
@@ -127,7 +127,7 @@ json.parse('{"invalid" json') // undefined
 
 Common object manipulation and intropsection functions
 
-#### `has`(obj: [Object][], property: [String][]): [Boolean][]
+#### `has`(obj: [Object][], property: [String][] [, separator: [String][] = '.']): [Boolean][]
 
 Determines if a specified key is a direct property of an object. This function is safe
 to call on objects that do not inherit from Object.prototype, unlike attempting to call `.hasOwnProperty`
@@ -137,6 +137,8 @@ on input objects
 
 * `obj` ([Object][]) - The object to introspect
 * `key` ([String][]) - The name of the property to locate
+* (optional) `separator` ([String][]) - Delimiter character
+  * default: `'.'`
 
 **returns** [Boolean][] - True of the key is defined on the input object.
 
@@ -148,6 +150,7 @@ object.has({a: 1}, 'a') // true
 object.has({}, 'test') // false
 object.has(Object.create(null), 'test') // false
 object.has({}, 'hasOwnProperty') // false
+object.has({one: {two: {three: 3}}}, 'one-two-three', '-') // true
 ```
 
 #### `get`(obj: [Object][], property: [String][] [, separator: [String][] = '.']): any
@@ -167,7 +170,7 @@ Returns the value from an object at a specified object path.
 
 ```javascript
 const {object} = require('@logdna/stdlib')
-const obj = {one: { two: three: 3 } }
+const obj = {one: {two: {three: 3}}}
 const value = object.get(obj, 'one-two-three', '-') // 3
 ```
 #### `set`(obj: `object`, property: `string`, value: `any` [, separator: [String][] = '.' ]): [Object][]
@@ -190,7 +193,7 @@ like arrays or maps. Only POJOs
 
 ```javascript
 const {object} = require('@logdna/stdlib')
-const obj = {one: { two: three: 3 } }
+const obj = {one: {two: {three: 3}}}
 const value = object.set(obj, 'four.five', 6)
 // {one: { two: three: 3 }, four: {five: 6}}
 ```

--- a/lib/object/get-property.js
+++ b/lib/object/get-property.js
@@ -7,7 +7,18 @@
 
 module.exports = function getProperty(obj, string = '', sep = '.') {
   /* eslint-disable-next-line no-eq-null */
-  if (obj == null) return undefined
+  if (obj == null || string == null) return undefined
+  if (typeof string !== 'string') {
+    throw new TypeError(
+      'second argument to object.getProperty must be a string'
+    )
+  }
+
+  if (sep && typeof sep !== 'string') {
+    throw new TypeError(
+      'third argument to object.getProperty must be a string'
+    )
+  }
 
   const parts = string.split(sep)
   let ret = obj
@@ -15,9 +26,11 @@ module.exports = function getProperty(obj, string = '', sep = '.') {
   let prop
   while ((prop = parts.shift())) {
     ret = ret[prop]
+
     /* eslint-disable-next-line no-eq-null */
     if (ret == null) return ret
   }
+
   return ret[last]
 }
 
@@ -30,7 +43,10 @@ module.exports = function getProperty(obj, string = '', sep = '.') {
  * @param {String} [sep='.'] Delimiter character
  * @returns {Mixed} Returns whatever value is found at the key
  * @example
- * const obj = {one: { two: three: 3 } }
+ * const obj = {one: {two: {three: 3}}}
  * const value = getProperty(obj, 'one-two-three', '-') // 3
+ * @example
+ * const obj = {one: 1}
+ * const value = getProperty(obj, 'one.two.three') // undefined
  */
 

--- a/lib/object/has-property.js
+++ b/lib/object/has-property.js
@@ -5,8 +5,36 @@
  * @author Eric Satterwhite
  **/
 
-module.exports = function hasOwnProperty(obj, prop) {
-  return Object.prototype.hasOwnProperty.call(obj, prop)
+module.exports = function hasProperty(obj, string = '', sep = '.') {
+  /* eslint-disable-next-line no-eq-null */
+  if (obj == null || string == null) return false
+  if (typeof string !== 'string') {
+    throw new TypeError(
+      'second argument to object.hasProperty must be a string'
+    )
+  }
+
+  if (sep && typeof sep !== 'string') {
+    throw new TypeError(
+      'third argument to object.hasProperty must be a string'
+    )
+  }
+
+  const parts = string.split(sep)
+  let ret = obj
+  /* eslint-disable-next-line no-unused-vars */
+  const last = parts.pop()
+  let prop
+  while ((prop = parts.shift())) {
+    if (Object.prototype.hasOwnProperty.call(ret, prop)) {
+      ret = ret[prop]
+    }
+
+    /* eslint-disable-next-line no-eq-null */
+    if (ret == null) return false
+  }
+
+  return Object.prototype.hasOwnProperty.call(ret, last)
 }
 
 /**
@@ -14,7 +42,8 @@ module.exports = function hasOwnProperty(obj, prop) {
  * do not inherit from Object.prototype
  * @function module:lib/object/has-property
  * @param {Object} obj The object to inspect
- * @param {String} key The name of the property to locate
+ * @param {String} string The key(s) value
+ * @param {String} [sep='.'] Delimiter character
  * @returns {Boolean} true if the key is defined on the root object
  * @example
  * object.has({a: 1}, 'a') // true
@@ -22,5 +51,7 @@ module.exports = function hasOwnProperty(obj, prop) {
  * object.has({}, 'test') // false
  * @example
  * object.has(Object.create(null), 'test') // false
+ * @example
+ * object.has({one: {two: {three: 3}}}, 'one-two-three', '-') // true
  **/
 

--- a/lib/object/set-property.js
+++ b/lib/object/set-property.js
@@ -12,9 +12,9 @@ function setProperty(obj, prop, value, sep = '.') {
       'second argument to object.setProperty must be a string'
     )
   }
+
   const keys = prop.split(sep)
   const last = keys.pop()
-
   if (!last) return obj
 
   _deepest(obj, keys)[last] = value
@@ -43,8 +43,8 @@ function _deepest(obj, keys) {
  * @param {String} [sep='.'] Delimit character
  * @returns {Object} Returns the modified object
  * @example
- * const obj = {one: { two: three: 3 } }
+ * const obj = {one: {two: {three: 3}}}
  * const value = setProperty(obj, 'four.five', 6)
- * // {one: { two: three: 3 }, four: {five: 6}}
+ * // {one: {two: {three: 3 }}, four: {five: 6}}
  */
 

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -17,14 +17,34 @@ test('object', async (t) => {
   })
 
   t.test('object.has', async (t) => {
-    const obj = {a: 'b'}
-    t.equal(object.has(obj, 'a'), true, 'true for defined property')
-    t.equal(
-      object.has(obj, 'hasOwnProperty')
-    , false
-    , 'false for propertied defined on prototype'
-    )
-  })
+    const has = object.has
+    const input = {
+      l1: {
+        l1p1: 2
+      , l1p2: {
+          l3p1: 4
+        , l3p2: null
+        }
+      }
+    }
+
+    t.equal(has(undefined, 'l1'), false, 'object being undefined')
+    t.equal(has(null, 'l1'), false, 'object being null')
+    t.equal(has(input), false, 'default string')
+    t.equal(has(input, 'l1p2.l3p1'), false, 'default separator')
+    t.equal(has(input, 'l1.l1p2.l3p1'), true, 'default separator')
+    t.equal(has(input, 'l1-l1p2-l3p1', '-'), true, 'custom separator')
+    t.equal(has(input, 'l1.l1p2.l3p2'), true, 'value being null')
+    t.equal(has(input, 'l1.l1p2.l3p2.l4p1'), false, 'props beyond null values')
+    t.equal(has(input, 'l1.l1p2.nope'), false, 'no match')
+    t.throws(() => {
+      object.has(input, 0)
+    }, /must be a string/ig)
+
+    t.throws(() => {
+      object.has(input, 'l1.l1p2.l3p2', 2)
+    }, /must be a string/ig)
+  }).catch(threw)
 
   t.test('object.get', async (t) => {
     const get = object.get
@@ -45,6 +65,13 @@ test('object', async (t) => {
     t.equal(get(input, 'l1-l1p2-l3p1', '-'), 4, 'custom separator')
     t.equal(get(input, 'l1.l1p2.l3p2.l4p1'), null, 'props beyond null values')
     t.equal(get(input, 'l1.l1p2.nope'), undefined, 'no match')
+    t.throws(() => {
+      object.get(input, 0)
+    }, /must be a string/ig)
+
+    t.throws(() => {
+      object.get(input, 'l1.l1p2.l3p2', 2)
+    }, /must be a string/ig)
   }).catch(threw)
 
   t.test('object.set', async (t) => {


### PR DESCRIPTION
Basically, copying the field-search method from `object.get`, which, I guess, is going to be pretty useful.

Semver: patch