### PR TITLE
fix(string): fix typecasting of boolean values

### DIFF
--- a/lib/string/typecast.js
+++ b/lib/string/typecast.js
@@ -8,8 +8,8 @@
 module.exports = function typecast(value) {
   if (value === 'null' || value === null) return null
   if (value === 'undefined' || value === undefined) return undefined
-  if (value === 'true') return true
-  if (value === 'false') return false
+  if (value === 'true' || value === true) return true
+  if (value === 'false' || value === false) return false
   if (value === '' || isNaN(value)) return value
   if (isFinite(value)) return parseFloat(value)
   return value

--- a/test/unit/string.js
+++ b/test/unit/string.js
@@ -169,6 +169,13 @@ test('string', async (t) => {
       value: 'false'
     , expected: false
     }, {
+      value: true
+    , expected: true
+    }, {
+      value: false
+    , expected: false
+    }, {
+    }, {
       value: '123'
     , expected: 123
     , message: 'integer value'


### PR DESCRIPTION
Allow pass through of boolean values. true and false are considered
finite values and will be passed to parse float and return a NaN rather
than true / false