### PR TITLE
feat: Add `use_null_prototype` option where applicable.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,13 +38,13 @@ pipeline {
       steps {
         error("A maintainer needs to approve this PR for CI by commenting")
       }
-    }    
+    }
     stage('Test Suite') {
       matrix {
         axes {
           axis {
             name 'NODE_VERSION'
-            values '12', '14', '16'
+            values '12', '14', '16', '18', '20'
           }
         }
 

--- a/README.md
+++ b/README.md
@@ -23,29 +23,47 @@ Standardized modular package exposing language constructs - free of business log
 > npm install @logdna/stdlib
 ```
 
-* [API](#api)
-  * [array](#array)
-    * [`toArray`(item: `any`): Array](#toarrayitem-any-array)
-  * [iter](#iter)
-    * [`cycle`(items: Array): Generator](#cycleitems-array-generator)
-  * [json](#json)
-    * [`parse`(input: String): Object](#parseinput-string-object)
-  * [object](#object)
-    * [`has`(obj: Object, property: String [, separator: String = '.']): Boolean](#hasobj-object-property-string--separator-string---boolean)
-    * [`get`(obj: Object, property: String [, separator: String = '.']): any](#getobj-object-property-string--separator-string---any)
-    * [`set`(obj: Object, property: String, value: `any` [, separator: String = '.' ]): Object](#setobj-object-property-string-value-any--separator-string----object)
-    * [`filter`(obj: Object, test: Function): Object](#filterobj-object-test-function-object)
-    * [`typecast`(obj: Object [, depth: Number = 1000]): Object](#typecastobj-object--depth-number--1000-object)
-  * [string](#string)
-    * [`camelcase`(text: String): String](#camelcasetext-string-string)
-    * [`lowercase`(text: String): String](#lowercasetext-string-string)
-    * [`uppercase`(text: String): String](#uppercasetext-string-string)
-    * [`slugify`(text: String [, separator: String = '-']): String](#slugifytext-string--separator-string----string)
-    * [`typecast`(text: String): Object](#typecasttext-string-object)
-  * [`typeOf`(element: `any`): String](#typeofelement-any-string)
-  * [`Callable`: Class](#callable-class)
-* [Authors](#authors)
-* [Contributors ✨](#contributors-)
+- [stdlib](#stdlib)
+- [Main Goals](#main-goals)
+- [Installation](#installation)
+- [API](#api)
+  - [array](#array)
+    - [`toArray`(item: `any`): Array](#toarrayitem-any-array)
+      - [Example](#example)
+  - [iter](#iter)
+    - [`cycle`(items: Array): Generator](#cycleitems-array-generator)
+      - [Example](#example-1)
+  - [json](#json)
+    - [`parse`(input: String): Object](#parseinput-string-object)
+      - [Example](#example-2)
+  - [object](#object)
+    - [`has`(obj: Object, property: String \[, separator: String = '.'\]): Boolean](#hasobj-object-property-string--separator-string---boolean)
+      - [Example](#example-3)
+    - [`get`(obj: Object, property: String \[, separator: String = '.'\]): any](#getobj-object-property-string--separator-string---any)
+      - [Example](#example-4)
+    - [`set`(obj: Object, property: String, value: `any` \[, separator: String = '.' \], \[use\_null\_prototype: Boolean\] = `true`): Object](#setobj-object-property-string-value-any--separator-string----use_null_prototype-boolean--true-object)
+      - [Example](#example-5)
+    - [`filter`(obj: Object, test: Function, \[use\_null\_prototype: Boolean = `true`\]): Object](#filterobj-object-test-function-use_null_prototype-boolean--true-object)
+      - [Example](#example-6)
+    - [`typecast`(obj: Object \[, depth: Number = 1000\], \[use\_null\_prototype: Boolean = `true`\]): Object](#typecastobj-object--depth-number--1000-use_null_prototype-boolean--true-object)
+      - [Example](#example-7)
+  - [string](#string)
+    - [`camelcase`(text: String): String](#camelcasetext-string-string)
+      - [Example](#example-8)
+    - [`lowercase`(text: String): String](#lowercasetext-string-string)
+      - [Example](#example-9)
+    - [`uppercase`(text: String): String](#uppercasetext-string-string)
+      - [Example](#example-10)
+    - [`slugify`(text: String \[, separator: String = '-'\]): String](#slugifytext-string--separator-string----string)
+      - [Example](#example-11)
+    - [`typecast`(text: String): Object](#typecasttext-string-object)
+      - [Example](#example-12)
+  - [`typeOf`(element: `any`): String](#typeofelement-any-string)
+      - [Example](#example-13)
+  - [`Callable`: Class](#callable-class)
+      - [Example](#example-14)
+- [Authors](#authors)
+- [Contributors ✨](#contributors-)
 
 ## API
 
@@ -174,11 +192,11 @@ const {object} = require('@logdna/stdlib')
 const obj = {one: {two: {three: 3}}}
 const value = object.get(obj, 'one-two-three', '-') // 3
 ```
-#### `set`(obj: [Object][], property: [String][], value: `any` [, separator: [String][] = '.' ]): [Object][]
+#### `set`(obj: [Object][], property: [String][], value: `any` [, separator: [String][] = '.' ], \[use_null_prototype: [Boolean][]\] = `true`): [Object][]
 
 Sets a property at the deepest level. Nested objects will be created if they do
 not exist. Returns the modified object. This will not work on complex Types
-like arrays or maps. Only POJOs
+like arrays or maps; Only POJOs.
 
 `NOTE`: if you find your self wanting to set the value at a specific index of an array - you probably want an object.
 
@@ -189,6 +207,8 @@ like arrays or maps. Only POJOs
 * `value` (`any`) - The value to set at the specified path
 * (*optional*) `separator` ([String][]) - Delimiter character
   * default: `'.'`
+* (*optional*) `use_null_prototype` ([Boolean][])- If `true` uses a `null` prototype for any objects that are created.
+  * defaut: `true`
 
 ##### Example
 
@@ -199,13 +219,12 @@ const value = object.set(obj, 'four.five', 6)
 // {one: { two: three: 3 }, four: {five: 6}}
 ```
 
-#### `filter`(obj: [Object][], test: [Function][]): [Object][]
+#### `filter`(obj: [Object][], test: [Function][], \[use_null_prototype: [Boolean][] = `true`\]): [Object][]
 
 Similar to array.filter, removes keys from an input object that do not pass the
 `test` function
 
-`NOTE`: This function returns a `null` object - `Object.create(null)` which does not
-inherit from Object.prototype
+`NOTE`: By default, his function returns a `null` object - `Object.create(null)` which does not inherit from Object.prototype.  This may be turned off by setting `use_null_prototype: false`
 
 **Arguments**
 
@@ -213,6 +232,8 @@ inherit from Object.prototype
 * `test` ([Function][]) - The function to be used to reject keys from the input object.
   If this function returns a `truthy` value, the key will be included in the final output. If `falsey`
   it will be excluded
+* (*optional*) `use_null_prototype` ([Boolean][])- If `true` uses a `null` prototype for any objects that are created.
+  * defaut: `true`
 
 ##### Example
 
@@ -228,7 +249,7 @@ object.filter({two: 2, three: 3}, (key) => {
 **returns** [Object][] An object containing only the keys which passed the test function.
 The return object will have a `null` prototype.
 
-#### `typecast`(obj: [Object][] [, depth: [Number][] = 1000]): [Object][]
+#### `typecast`(obj: [Object][] [, depth: [Number][] = 1000], \[use_null_prototype: [Boolean][] = `true`\]): [Object][]
 
 Recursively typecast string values of enumerable object properties,
 using [`string.typecast()`](#typecasttext-string-object)
@@ -237,6 +258,8 @@ using [`string.typecast()`](#typecasttext-string-object)
 
 * `obj` ([Object][]) - The input object
 * `key` ([Number][]) - The maximum depth to recursively typecast
+* (*optional*) `use_null_prototype` ([Boolean][])- If `true` uses a `null` prototype for any objects that are created.
+  * defaut: `true`
 
 **returns** [Object][] A *new* object with all string properties typecast.
 

--- a/lib/object/filter.js
+++ b/lib/object/filter.js
@@ -8,8 +8,13 @@
 const typeOf = require('../type-of.js')
 module.exports = filter
 
-function filter(obj, fn) {
-  const out = Object.create(null)
+function filter(obj, fn, use_null_prototype = true) {
+  let out
+  if (use_null_prototype) {
+    out = Object.create(null)
+  } else {
+    out = {}
+  }
   if (typeOf(obj) !== 'object') return out
   for (const key of Object.keys(obj)) {
     if (fn(key)) out[key] = obj[key]
@@ -22,6 +27,8 @@ function filter(obj, fn) {
  * @function module:lib/object/filter
  * @param {Object} obj The object to filter
  * @param {Function} fn A test function. return a truthy value to keep the key
+ * @param {Boolean} [use_null_prototype=true] If true, creates a new object with the
+ *  prototype of null. This is minutely more efficient, but can cause deep equality issues.
  * @example
  * object.filter({two: 2, three: 3}, (key) =>{
  *    return key.match(/ee$/)

--- a/lib/object/set-property.js
+++ b/lib/object/set-property.js
@@ -6,7 +6,8 @@
 
 module.exports = setProperty
 
-function setProperty(obj, prop, value, sep = '.') {
+function setProperty(obj, prop, value, sep = '.', use_null_prototype = true) {
+  sep = sep || '.' // handle `null`
   if (typeof prop !== 'string') {
     throw new TypeError(
       'second argument to object.setProperty must be a string'
@@ -17,15 +18,19 @@ function setProperty(obj, prop, value, sep = '.') {
   const last = keys.pop()
   if (!last) return obj
 
-  _deepest(obj, keys)[last] = value
+  _deepest(obj, keys, use_null_prototype)[last] = value
   return obj
 }
 
-function _deepest(obj, keys) {
+function _deepest(obj, keys, use_null_prototype) {
   if (!keys.length) return obj
   for (const key of keys) {
     if (!obj[key]) {
-      obj[key] = Object.create(null)
+      if (use_null_prototype) {
+        obj[key] = Object.create(null)
+      } else {
+        obj[key] = {}
+      }
     }
     obj = obj[key]
   }
@@ -41,6 +46,8 @@ function _deepest(obj, keys) {
  * @param {String} string The key(s) value
  * @param {*} value The value to set
  * @param {String} [sep='.'] Delimit character
+ * @param {Boolean} [use_null_prototype=true] If true, creates a new object with the
+ *  prototype of null. This is minutely more efficient, but can cause deep equality issues.
  * @returns {Object} Returns the modified object
  * @example
  * const obj = {one: {two: {three: 3}}}

--- a/lib/object/typecast.js
+++ b/lib/object/typecast.js
@@ -3,8 +3,14 @@
 const typecast = require('../string/typecast.js')
 const typeOf = require('../type-of.js')
 
-module.exports = function typecastObject(obj, depth = 1000) {
-  const out = Object.create(null)
+module.exports = function typecastObject(obj, depth = 1000, use_null_prototype = true) {
+  depth = depth || 1000 // handle `null`
+  let out
+  if (use_null_prototype) {
+    out = Object.create(null)
+  } else {
+    out = {}
+  }
   for (const [key, value] of Object.entries(obj)) {
     if (typeof value === 'string') {
       out[key] = typecast(value)
@@ -12,7 +18,7 @@ module.exports = function typecastObject(obj, depth = 1000) {
     }
 
     if (depth && typeOf(value) === 'object') {
-      out[key] = typecastObject(value, --depth)
+      out[key] = typecastObject(value, --depth, use_null_prototype)
       continue
     }
 
@@ -26,7 +32,9 @@ module.exports = function typecastObject(obj, depth = 1000) {
  * Recursively typecast string values of enumerable object properties.
  * @function module:lib/object/typecast
  * @param {Object} obj The input object
- * @param {Object} depth The maximum depth to recursively typecast
+ * @param {Object} [depth=1000] The maximum depth to recursively typecast
+ * @param {Boolean} [use_null_prototype=true] If true, creates a new object with the
+ *  prototype of null. This is minutely more efficient, but can cause deep equality issues.
  * @returns {Object} Returns a *new* object
  * @example
  * const obj = {foo: '1', bar: 'null', baz: 'three', qux: {foo: '2'}}

--- a/test/unit/object.js
+++ b/test/unit/object.js
@@ -130,6 +130,34 @@ test('object', async (t) => {
         }
       }, 'subsequent calls override previous values')
     }
+
+    {
+      const result = object.set(input, 'foo.fizz.fab', {hello: 'there'}, null, false)
+      t.same(result, {
+        x: 2
+      , foo: {
+          bar: 100
+        , fizz: {
+            fab: {hello: 'there'}
+          }
+        }
+      , bar: {
+          baz: {
+            nested: [1, 2]
+          }
+        }
+      }, 'set successful')
+      t.equal(
+        result.foo.fizz.constructor.name
+      , 'Object'
+      , 'parent prototype is correct'
+      )
+      t.equal(
+        result.foo.fizz.fab.constructor.name
+      , 'Object'
+      , 'child prototype is correct'
+      )
+    }
   })
 
   t.test('object.filter', async (t) => {
@@ -158,6 +186,16 @@ test('object', async (t) => {
       })
 
       t.same(output, {three: 3}, 'filters out non matching keys')
+    }
+
+    {
+      const input = {one: 1, two: 2, three: 3, four: 4}
+      const output = object.filter(input, (key) => {
+        return !key.match(/o/ig)
+      }, false)
+
+      t.same(output, {three: 3}, 'filter worked')
+      t.equal(output.constructor.name, 'Object', 'prototype is correct')
     }
   })
 
@@ -228,6 +266,17 @@ test('object', async (t) => {
           }
         }
       }, 'respects depth')
+    }
+
+    {
+      const input = {
+        foo: 'true'
+      }
+      const result = object.typecast(input, null, false)
+      t.same(result, {
+        foo: true
+      }, 'typecast was successful')
+      t.same(result.constructor.name, 'Object', 'typecasted object has prototype')
     }
   })
 }).catch(threw)


### PR DESCRIPTION
This library defaults to use a `null` prototype when creating objects, which is slightly more efficient. However, deep equality assertions such as NodeJS's `deepStringEqual` will fail if the prototypes don't match. This causes users to have to re-create certain objects when testing, which is cumbersome.

This adds `use_null_prototype` which will use `Object` as the prototype when objects are created. This is mostly useful in `filter`, however the option was added across multiple functions for consistency.